### PR TITLE
auto release and upload assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          mkdir csv-converter \
+            && cp *.php csv-converter \
+            && cp *.bash csv-converter \
+            && cp -r config csv-converter \
+            && cp -r project csv-converter \
+            && cp -r utils csv-converter \
+            && tar -zcf csv-converter.tar.gz csv-converter
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: csv-converter.tar.gz
+

--- a/README.md
+++ b/README.md
@@ -324,3 +324,12 @@ php ./add_double_quote.php ./dump.csv
 "1","99119","trajiro","寅次郎(st_99119)","trajiro@example.com","0"
 "","99120","yasujiro","小津安二郎(st_99120)","yasujiro@example.com","0"
 ```
+
+# リリース
+
+下記を実行してください。
+自動でGitHubにリリースが作成され、成果物(csv-converter.tar.gz)がアップロードされます。
+```sh
+$bash release.bash
+```
+

--- a/release.bash
+++ b/release.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+NOW=$(TZ='Asia/Tokyo' date +%Y%m%d%H%M%S)
+git tag $NOW
+git push origin --tags
+


### PR DESCRIPTION
release.bashを実行すると、自動でリリースが作られcsv-converter.tar.gzがアップロードされるようにしました。
下記がリリースの例です。
https://github.com/mahaker/csv-convertor/releases/tag/20230620095157

リリースを作るだけでリポジトリをtar化したものはできるのですが
csv-converter.tar.gzはランタイムに必要なファイルに絞って作成しているので、幾分か軽量化されています。